### PR TITLE
Fix go vet and go fmt errors

### DIFF
--- a/lokalise.go
+++ b/lokalise.go
@@ -1,23 +1,24 @@
 package main
 
 import (
-	"os"
-	"bytes"
-	"net/http"
-	"github.com/urfave/cli"
-	"log"
-	"io/ioutil"
-	"time"
-	"encoding/json"
-	"github.com/fatih/color"
-	"fmt"
-	"strings"
-	"io"
-	"github.com/briandowns/spinner"
-	"mime/multipart"
-	"path/filepath"
 	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
 	"github.com/BurntSushi/toml"
+	"github.com/briandowns/spinner"
+	"github.com/fatih/color"
+	"github.com/urfave/cli"
 )
 
 func main() {
@@ -50,9 +51,9 @@ func main() {
 
 	app.Commands = []cli.Command{
 		{
-			Name:  "list",
+			Name:    "list",
 			Aliases: []string{"l"},
-			Usage: "List your projects at Lokalise.",
+			Usage:   "List your projects at Lokalise.",
 			Action: func(c *cli.Context) error {
 				var conf Config
 
@@ -122,92 +123,92 @@ func main() {
 			},
 		},
 		{
-			Name:  "export",
+			Name:    "export",
 			Aliases: []string{"d"},
-			Usage: "Downloads language files.",
+			Usage:   "Downloads language files.",
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name: "type",
+					Name:  "type",
 					Usage: "File format (strings, xliff, plist, xml, properties, json, po, php, ini, yml, xls) (single value, required)",
 				},
 				cli.StringFlag{
-					Name: "dest",
+					Name:  "dest",
 					Usage: "Destination directory on local filesystem (for the .zip bundle) (/dir)",
 				},
 				cli.StringFlag{
-					Name: "unzip_to",
+					Name:  "unzip_to",
 					Usage: "Unzip downloaded bundle to a specified directory (/dir) and remove the .zip. Use --keep_zip to not avoid deletion.",
 				},
 				cli.StringFlag{
-					Name: "keep_zip",
+					Name:  "keep_zip",
 					Usage: "Keep downloaded .zip, if --unzip_to is used. (`0/1`)",
 				},
 				cli.StringFlag{
-					Name: "langs",
+					Name:  "langs",
 					Usage: "Languages to include. Don't specify for all languages. (comma separated)",
 				},
 				cli.StringFlag{
-					Name: "use_original",
+					Name:  "use_original",
 					Usage: "Use original filenames/formats (`0/1`)",
 				},
 				cli.StringFlag{
-					Name: "filter",
+					Name:  "filter",
 					Usage: "Filter by 'translated', 'nonfuzzy', 'nonhidden' fields (comma separated)",
 				},
 				cli.StringFlag{
-					Name: "bundle_structure",
+					Name:  "bundle_structure",
 					Usage: ".ZIP bundle structure (see docs.lokalise.co for placeholders)",
 				},
 				cli.StringFlag{
-					Name: "webhook_url",
+					Name:  "webhook_url",
 					Usage: "Sends POST['file'] if specified (url)",
 				},
 				cli.StringFlag{
-					Name: "export_all",
+					Name:  "export_all",
 					Usage: "Include all platform keys (`0/1`)",
 				},
 				cli.StringFlag{
-					Name: "ota_plugin_bundle",
+					Name:  "ota_plugin_bundle",
 					Usage: "Generate plugin for OTA iOS plugin (`0/1`)",
 				},
 				cli.StringFlag{
-					Name: "export_empty",
+					Name:  "export_empty",
 					Usage: "How to export empty strings (empty, base, skip)",
 				},
 				cli.StringFlag{
-					Name: "include_comments",
+					Name:  "include_comments",
 					Usage: "Include comments in exported file (`0/1`)",
 				},
 				cli.StringFlag{
-					Name: "include_pids",
+					Name:  "include_pids",
 					Usage: "Other projects ID's, which keys to include in this export (comma separated)",
 				},
 				cli.StringFlag{
-					Name: "tags",
+					Name:  "tags",
 					Usage: "Filter keys by tags (comma separated)",
 				},
 				cli.StringFlag{
-					Name: "yaml_include_root",
+					Name:  "yaml_include_root",
 					Usage: "Include language ISO code as root key in YAML export (`0/1`)",
 				},
 				cli.StringFlag{
-					Name: "json_unescaped_slashes",
+					Name:  "json_unescaped_slashes",
 					Usage: "Leave forward slashes unescaped in JSON export (`0/1`)",
 				},
 				cli.StringFlag{
-					Name: "export_sort",
+					Name:  "export_sort",
 					Usage: "Key sort order (first_added, last_added, last_updated, a_z, z_a)",
 				},
 				cli.StringFlag{
-					Name: "replace_breaks",
+					Name:  "replace_breaks",
 					Usage: "Replace link breaks with \\n (`0/1`)",
 				},
 				cli.StringFlag{
-					Name: "no_language_folders",
+					Name:  "no_language_folders",
 					Usage: "Don't use language folders (`0/1`)",
 				},
 				cli.StringFlag{
-					Name: "triggers",
+					Name:  "triggers",
 					Usage: "Trigger integration export. Allowed values are 'amazons3' and 'gcs' (comma separated)",
 				},
 			},
@@ -229,11 +230,11 @@ func main() {
 					return cli.NewExitError("ERROR: --token is required.  Run `lokalise help` for all options.", 5)
 				}
 
-				projectId := c.Args().First();
-				if (projectId == "") {
-					projectId = conf.Project
+				projectID := c.Args().First()
+				if projectID == "" {
+					projectID = conf.Project
 				}
-				if (projectId == "") {
+				if projectID == "" {
 					return cli.NewExitError("ERROR: Project ID is required as first command option. Run `lokalise help export` for all options.", 5)
 				}
 
@@ -247,111 +248,111 @@ func main() {
 					return cli.NewExitError("ERROR: --type is required. Run `lokalise help export` for all options.", 5)
 				}
 
-				theUrl := "api_token=" + apiToken + `&id=` + projectId + `&type=` + fileType
+				theURL := "api_token=" + apiToken + `&id=` + projectID + `&type=` + fileType
 
 				langs := c.String("langs")
-				if (langs != "") {
+				if langs != "" {
 					langs = s2json(langs)
-					theUrl += "&langs=" + langs
+					theURL += "&langs=" + langs
 				}
 
 				useOriginal := c.String("use_original")
-				if (useOriginal != "") {
-					theUrl += "&use_original=" + useOriginal
+				if useOriginal != "" {
+					theURL += "&use_original=" + useOriginal
 				}
 
 				noLanguageFolders := c.String("no_language_folders")
-				if (noLanguageFolders != "") {
-					theUrl += "&switch_no_language_folders=" + noLanguageFolders
+				if noLanguageFolders != "" {
+					theURL += "&switch_no_language_folders=" + noLanguageFolders
 				}
 
 				filter := c.String("filter")
-				if (filter != "") {
+				if filter != "" {
 					filter = s2json(filter)
-					theUrl += "&filter=" + filter
+					theURL += "&filter=" + filter
 				}
 
 				triggers := c.String("triggers")
-				if (triggers != "") {
+				if triggers != "" {
 					triggers = s2json(triggers)
-					theUrl += "&triggers=" + triggers
+					theURL += "&triggers=" + triggers
 				}
 
 				bundleStructure := c.String("bundle_structure")
-				if (bundleStructure != "") {
-					theUrl += "&bundle_structure=" + bundleStructure
+				if bundleStructure != "" {
+					theURL += "&bundle_structure=" + bundleStructure
 				}
 
-				webhookUrl := c.String("webhook_url")
-				if (webhookUrl != "") {
-					theUrl += "&webhook_url=" + webhookUrl
+				webhookURL := c.String("webhook_url")
+				if webhookURL != "" {
+					theURL += "&webhook_url=" + webhookURL
 				}
 
 				exportAll := c.String("export_all")
-				if (exportAll != "") {
-					theUrl += "&export_all=" + exportAll
+				if exportAll != "" {
+					theURL += "&export_all=" + exportAll
 				}
 
 				otaPluginBundle := c.String("ota_plugin_bundle")
-				if (otaPluginBundle != "") {
-					theUrl += "&ota_plugin_bundle=" + otaPluginBundle
+				if otaPluginBundle != "" {
+					theURL += "&ota_plugin_bundle=" + otaPluginBundle
 				}
 
 				exportEmpty := c.String("export_empty")
-				if (exportEmpty != "") {
-					theUrl += "&export_empty=" + exportEmpty
+				if exportEmpty != "" {
+					theURL += "&export_empty=" + exportEmpty
 				}
 
 				exportSort := c.String("export_sort")
-				if (exportSort != "") {
-					theUrl += "&export_sort=" + exportSort
+				if exportSort != "" {
+					theURL += "&export_sort=" + exportSort
 				}
 
 				includeComments := c.String("include_comments")
-				if (includeComments != "") {
-					theUrl += "&include_comments=" + includeComments
+				if includeComments != "" {
+					theURL += "&include_comments=" + includeComments
 				}
 
 				replaceBreaks := c.String("replace_breaks")
-				if (replaceBreaks != "") {
-					theUrl += "&replace_breaks=" + replaceBreaks
+				if replaceBreaks != "" {
+					theURL += "&replace_breaks=" + replaceBreaks
 				}
 
 				yamlIncludeRoot := c.String("yaml_include_root")
-				if (yamlIncludeRoot != "") {
-					theUrl += "&yaml_include_root=" + yamlIncludeRoot
+				if yamlIncludeRoot != "" {
+					theURL += "&yaml_include_root=" + yamlIncludeRoot
 				}
 
 				jsonUnescapedSlashes := c.String("json_unescaped_slashes")
-				if (jsonUnescapedSlashes != "") {
-					theUrl += "&json_unescaped_slashes=" + jsonUnescapedSlashes
+				if jsonUnescapedSlashes != "" {
+					theURL += "&json_unescaped_slashes=" + jsonUnescapedSlashes
 				}
 
 				includePids := c.String("include_pids")
-				if (includePids != "") {
+				if includePids != "" {
 					includePids = s2json(includePids)
-					theUrl += "&include_pids=" + includePids
+					theURL += "&include_pids=" + includePids
 				}
 
 				tags := c.String("tags")
-				if (tags != "") {
+				if tags != "" {
 					tags = s2json(tags)
-					theUrl += "&tags=" + tags
+					theURL += "&tags=" + tags
 				}
 
 				unzipTo := c.String("unzip_to")
 				keepZip := c.String("keep_zip")
-				if (keepZip == "") {
+				if keepZip == "" {
 					keepZip = "0"
 				}
 
 				cWhite := color.New(color.FgHiWhite)
 				cGreen := color.New(color.FgGreen)
 
-				theSpinner := spinner.New(spinner.CharSets[9], 100 * time.Millisecond)
+				theSpinner := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 				theSpinner.Start()
 				fmt.Print("Requesting...")
-				body := strings.NewReader(theUrl)
+				body := strings.NewReader(theURL)
 				req, err := http.NewRequest("POST", "https://api.lokalise.co/api/project/export", body)
 				if err != nil {
 					log.Fatal(err)
@@ -367,7 +368,6 @@ func main() {
 				response, err := ioutil.ReadAll(resp.Body)
 				defer resp.Body.Close()
 
-
 				var dat map[string]interface{}
 				if err := json.Unmarshal([]byte(response), &dat); err != nil {
 					panic(err)
@@ -382,28 +382,27 @@ func main() {
 					e := dat["response"].(map[string]interface{})["message"]
 					fmt.Println(e)
 					return cli.NewExitError("ERROR: API returned error (see above)", 7)
-				} else {
-					file = dat["bundle"].(map[string]interface{})["file"].(string)
 				}
+				file = dat["bundle"].(map[string]interface{})["file"].(string)
 
-				fileUrl := "https://s3-eu-west-1.amazonaws.com/lokalise-assets/" + file
+				fileURL := "https://s3-eu-west-1.amazonaws.com/lokalise-assets/" + file
 				filename := strings.Split(file, "/")[4]
 
 				theSpinner.Stop()
 
 				cWhite.Println()
 				cWhite.Print("Remote ")
-				cGreen.Print(fileUrl + "... ")
+				cGreen.Print(fileURL + "... ")
 				cWhite.Println("OK")
 
 				cWhite.Print("Local ")
 				cGreen.Print(dest + "/" + filename + "... ")
 
-				downloadFile(dest + "/" + filename, fileUrl)
+				downloadFile(dest+"/"+filename, fileURL)
 				cWhite.Println("OK")
 
-				if (unzipTo != "") {
-					files, err := Unzip(dest + "/" + filename, unzipTo)
+				if unzipTo != "" {
+					files, err := Unzip(dest+"/"+filename, unzipTo)
 
 					if err != nil {
 						cWhite.Println("Error unzipping files")
@@ -411,7 +410,7 @@ func main() {
 						cWhite.Print("Unzipped ")
 						cGreen.Print(strings.Join(files, ", ") + " ")
 						cWhite.Println("OK")
-						if (keepZip == "0") {
+						if keepZip == "0" {
 							os.Remove(dest + "/" + filename)
 						}
 					}
@@ -422,44 +421,44 @@ func main() {
 			},
 		},
 		{
-			Name:  "import",
-			Usage: "Upload language files.",
+			Name:    "import",
+			Usage:   "Upload language files.",
 			Aliases: []string{"u"},
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name: "file",
+					Name:  "file",
 					Usage: "A single file, or comma-separated list of files or file masks on local filesystem to import (any of the supported file formats) (required). Make sure to escape * if using file masks (\\*).",
 				},
 				cli.StringFlag{
-					Name: "lang_iso",
+					Name:  "lang_iso",
 					Usage: "Language of the translations being imported (reqired)",
 				},
 				cli.StringFlag{
-					Name: "replace",
+					Name:  "replace",
 					Usage: "Shall existing translations be replaced (`0/1`)",
 				},
 				cli.StringFlag{
-					Name: "fill_empty",
+					Name:  "fill_empty",
 					Usage: "If values are empty, keys will be copied to values (`0/1`)",
 				},
 				cli.StringFlag{
-					Name: "distinguish",
+					Name:  "distinguish",
 					Usage: "Distinguish similar keys in different files (`0/1`)",
 				},
 				cli.StringFlag{
-					Name: "hidden",
+					Name:  "hidden",
 					Usage: "Hide imported keys from contributors (`0/1`)",
 				},
 				cli.StringFlag{
-					Name: "tags",
+					Name:  "tags",
 					Usage: "Tags list for newly imported keys (comma separated)",
 				},
 				cli.StringFlag{
-					Name: "use_trans_mem",
+					Name:  "use_trans_mem",
 					Usage: "Use translation memory to fill 100% matches (`0/1`)",
 				},
 				cli.StringFlag{
-					Name: "replace_breaks",
+					Name:  "replace_breaks",
 					Usage: "Replace \\n with line breaks (`0/1`)",
 				},
 			},
@@ -481,18 +480,18 @@ func main() {
 					return cli.NewExitError("ERROR: --token is required.  Run `lokalise help` for all options.", 5)
 				}
 
-				theUrl := "https://api.lokalise.co/api/project/import"
+				theURL := "https://api.lokalise.co/api/project/import"
 
-				projectId := c.Args().First();
-				if (projectId == "") {
-					projectId = conf.Project
+				projectID := c.Args().First()
+				if projectID == "" {
+					projectID = conf.Project
 				}
-				if (projectId == "") {
+				if projectID == "" {
 					return cli.NewExitError("ERROR: Project ID is required as first command option. Run `lokalise help import` for all options.", 5)
 				}
 
 				file := c.String("file")
-				if (file == "") {
+				if file == "" {
 					return cli.NewExitError("ERROR: --file required.  Run `lokalise help import` for all options.", 5)
 				}
 
@@ -509,20 +508,20 @@ func main() {
 				replaceBreaks := c.String("replace_breaks")
 
 				tags := c.String("tags")
-				if (tags != "") {
+				if tags != "" {
 					tags = s2json(tags)
 				}
 
 				extraParams := map[string]string{
-					"id": projectId,
-					"api_token": apiToken,
-					"lang_iso": langIso,
-					"fill_empty": fillEmpty,
-					"hidden": hidden,
-					"distinguish": distinguish,
-					"replace": replace,
-					"tags": tags,
-					"use_trans_mem": useTransMem,
+					"id":             projectID,
+					"api_token":      apiToken,
+					"lang_iso":       langIso,
+					"fill_empty":     fillEmpty,
+					"hidden":         hidden,
+					"distinguish":    distinguish,
+					"replace":        replace,
+					"tags":           tags,
+					"use_trans_mem":  useTransMem,
 					"replace_breaks": replaceBreaks,
 				}
 
@@ -539,14 +538,14 @@ func main() {
 					}
 
 					for _, filename := range files {
-						theSpinner := spinner.New(spinner.CharSets[9], 100 * time.Millisecond)
+						theSpinner := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 						theSpinner.Start()
 
 						cWhite.Print("Uploading ")
 						cWhite.Print(filename)
 						cWhite.Print("... ")
 
-						request, err := newfileUploadRequest(theUrl, extraParams, "file", filename)
+						request, err := newfileUploadRequest(theURL, extraParams, "file", filename)
 
 						if err != nil {
 							log.Fatal(err)
@@ -571,19 +570,18 @@ func main() {
 							e := dat["response"].(map[string]interface{})["message"]
 							fmt.Println(e)
 							return cli.NewExitError("ERROR: API returned error (see above)", 7)
-						} else {
-							skipped, _ := dat["result"].(map[string]interface{})["skipped"].(float64)
-							inserted, _ := dat["result"].(map[string]interface{})["inserted"].(float64)
-							updated, _ := dat["result"].(map[string]interface{})["updated"].(float64)
-
-							cGreen.Print("Inserted ")
-							cWhite.Print(inserted)
-							cGreen.Print(", skipped ")
-							cWhite.Print(skipped)
-							cGreen.Print(", updated ")
-							cWhite.Print(updated)
-							cGreen.Println(" keys.")
 						}
+						skipped, _ := dat["result"].(map[string]interface{})["skipped"].(float64)
+						inserted, _ := dat["result"].(map[string]interface{})["inserted"].(float64)
+						updated, _ := dat["result"].(map[string]interface{})["updated"].(float64)
+
+						cGreen.Print("Inserted ")
+						cWhite.Print(inserted)
+						cGreen.Print(", skipped ")
+						cWhite.Print(skipped)
+						cGreen.Print(", updated ")
+						cWhite.Print(updated)
+						cGreen.Println(" keys.")
 					}
 				}
 
@@ -680,7 +678,7 @@ func Unzip(src, dest string) ([]string, error) {
 				return filenames, err
 			}
 			f, err := os.OpenFile(
-				fpath, os.O_WRONLY | os.O_CREATE | os.O_TRUNC, f.Mode())
+				fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
 			if err != nil {
 				return filenames, err
 			}


### PR DESCRIPTION
This PR fixes formatting and linting errors in the source code. I'm preparing a split of functionality as #1 mentions but I want'ed to get this out of the way so the changes are more clear.

Go has some strict conventions on the formatting ([gofmt](https://golang.org/cmd/gofmt/)) and structuring of source code ([govet](https://golang.org/cmd/vet/) and [gometalinter](https://github.com/alecthomas/gometalinter)). This is just a run-though of these. The changes are as follows:

- Imports are sorted by name and std lib and external libs are separated
- Struct fields are aligned with whitespaces
- Unneeded parenthesis in `if` statements removed
- `else` statements removed as the code returns early anyway
- Abbreviations are upper cased so `Url` becomes `URL`