### PR TITLE
[WIP] Split Web API functionality and CLI logic into different packages

### DIFF
--- a/lokalise/error.go
+++ b/lokalise/error.go
@@ -1,0 +1,82 @@
+package lokalise
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Code is an API request status code.
+type Code string
+
+const (
+	// OK indicates a successful request.
+	OK Code = "200"
+	// MissingAPIToken indicates a missing API token in the request.
+	MissingAPIToken Code = "401"
+	// InvalidAPIToken indicates an invalid API token in the request.
+	InvalidAPIToken Code = "4011"
+	// NoData indicates no data in the body of an HTTP POST request.
+	NoData Code = "4012"
+	// AccessDenied indicates missing permissions to access the requested resource.
+	AccessDenied Code = "403"
+	// InvalidCall indicates an invalid API request.
+	InvalidCall Code = "404"
+	// Custom indicates a custom error. Refer to field Message of Error for details.
+	Custom Code = "4040"
+	// NotJSON indicates a non-JSON payload in a request where JSON was expected.
+	NotJSON Code = "4042"
+	// WrongLanguageCode indicates an invalid language code.
+	WrongLanguageCode Code = "4043"
+	// LanguageNotAvailable indicates that the requested language is not available for the project.
+	LanguageNotAvailable Code = "4044"
+	// LanguageNotSpecified indicates that the language is missing in the request.
+	LanguageNotSpecified Code = "4045"
+	// InvalidFile indicates that an unsupported file format is used in the request.
+	InvalidFile Code = "4046"
+	// InvalidExportType indicates an invalid export type is used in the request.
+	InvalidExportType Code = "4047"
+	// RateLimit indicates to many requests in a short period of time.
+	RateLimit Code = "4048"
+	// MissingRequestParameter indicates a missing required parameter.
+	MissingRequestParameter Code = "4049"
+	// LanguageExist indicates the specified language already exist for project.
+	LanguageExist Code = "4050"
+)
+
+// Error represents an API request error. When the API is not able to complete a request
+// an error code and possibly a message is returned indicating why the request failed.
+type Error struct {
+	Code    Code
+	Message string
+}
+
+// Error implements the error interface.
+func (err *Error) Error() string {
+	return fmt.Sprintf("lokalise: %s %s", err.Code, err.Message)
+}
+
+// Assert that Error implements the error interface.
+var _ error = &Error{}
+
+func errorFromResponse(resp response) error {
+	if resp.Status != "error" {
+		return nil
+	}
+	return &Error{
+		Code:    resp.Code,
+		Message: resp.Message,
+	}
+}
+
+func errorFromStatus(resp *http.Response) error {
+	if resp == nil {
+		return nil
+	}
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+	return &Error{
+		Code:    Custom,
+		Message: fmt.Sprintf("api request did not respond with status 200. Got %s", resp.Status),
+	}
+}

--- a/lokalise/export.go
+++ b/lokalise/export.go
@@ -1,0 +1,104 @@
+package lokalise
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// ExportOptions represents available options for a project export request.
+type ExportOptions struct {
+	Languages            []string
+	UseOriginal          *bool
+	Filter               []string
+	BundleStructure      *string
+	WebhookURL           *string
+	ExportAll            *bool
+	ExportEmpty          *string
+	IncludeComments      *bool
+	IncludePIDs          []string
+	Tags                 []string
+	ExportSort           *string
+	ReplaceBreaks        *bool
+	YAMLIncludeRoot      *bool
+	JSONUnescapedSlashes *bool
+	Triggers             []string
+}
+
+// Bundle represents file locations for a project export bundle. If a webhook URL was
+// specified in the ExportOptions the FullFile field is not set.
+type Bundle struct {
+	File     string `json:"file"`
+	FullFile string `json:"full_file"`
+}
+
+type exportResponse struct {
+	Bundle   Bundle   `json:"bundle"`
+	Response response `json:"response"`
+}
+
+// Export initiates an export of project with ID projectID in file type fileType and returns the
+// file locations for the export bundle.
+//
+// If WebhookURL is set in opts the FullFile field is not set on the bundle.
+//
+// In case of API request errors an error of type Error is returned.
+func Export(apiToken, projectID, fileType string, opts *ExportOptions) (Bundle, error) {
+	form := &url.Values{}
+	formAdd(form, "api_token", &apiToken)
+	formAdd(form, "id", &projectID)
+	formAdd(form, "type", &fileType)
+	formAdd(form, "langs", jsonArray(opts.Languages))
+	formAdd(form, "use_original", boolString(opts.UseOriginal))
+	formAdd(form, "filter", jsonArray(opts.Filter))
+	formAdd(form, "bundle_structure", opts.BundleStructure)
+	formAdd(form, "webhook_url", opts.WebhookURL)
+	formAdd(form, "export_all", boolString(opts.ExportAll))
+	formAdd(form, "export_empty", opts.ExportEmpty)
+	formAdd(form, "include_comments", boolString(opts.IncludeComments))
+	formAdd(form, "include_pids", jsonArray(opts.IncludePIDs))
+	formAdd(form, "tags", jsonArray(opts.Tags))
+	formAdd(form, "export_sort", opts.ExportSort)
+	formAdd(form, "replace_breaks", boolString(opts.ReplaceBreaks))
+	formAdd(form, "yaml_include_root", boolString(opts.YAMLIncludeRoot))
+	formAdd(form, "json_unescaped_slashes", boolString(opts.JSONUnescapedSlashes))
+	formAdd(form, "triggers", jsonArray(opts.Triggers))
+
+	req, err := http.NewRequest("POST", api("/project/export"), strings.NewReader(form.Encode()))
+	if err != nil {
+		return Bundle{}, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := callAPI(req)
+	if err != nil {
+		return Bundle{}, err
+	}
+	if err := errorFromStatus(resp); err != nil {
+		return Bundle{}, err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return Bundle{}, err
+	}
+	var dat exportResponse
+	if err := json.Unmarshal(body, &dat); err != nil {
+		return Bundle{}, err
+	}
+	if err := errorFromResponse(dat.Response); err != nil {
+		return Bundle{}, err
+	}
+	if opts.WebhookURL == nil {
+		dat.Bundle.FullFile = assetURL + dat.Bundle.File
+	}
+	return dat.Bundle, nil
+}
+
+func formAdd(v *url.Values, field string, value *string) {
+	if value == nil {
+		return
+	}
+	v.Add(field, *value)
+}

--- a/lokalise/import.go
+++ b/lokalise/import.go
@@ -1,0 +1,135 @@
+package lokalise
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+// ImportOptions represents available options for importing files to a project.
+type ImportOptions struct {
+	Replace       *bool
+	FillEmpty     *bool
+	Distinguish   *bool
+	Hidden        *bool
+	Tags          []string
+	ReplaceBreaks *bool
+}
+
+// ImportResult represents the outcome of a file upload.
+type ImportResult struct {
+	Skipped  int64 `json:"skipped"`
+	Inserted int64 `json:"inserted"`
+	Updated  int64 `json:"updated"`
+}
+
+type importResponse struct {
+	Result   ImportResult `json:"result"`
+	Response response     `json:"response"`
+}
+
+// Import uploads a file with translations in language langISO to a Lokalise project with ID projectID.
+// Customize the import by setting any options in opts.
+//
+// In case of API request errors an error of type Error is returned.
+func Import(apiToken, projectID, file, langISO string, opts *ImportOptions) (ImportResult, error) {
+	request, err := newfileUploadRequest(apiToken, projectID, file, langISO, opts)
+	if err != nil {
+		return ImportResult{}, err
+	}
+	resp, err := callAPI(request)
+	if err != nil {
+		return ImportResult{}, err
+	}
+	if err := errorFromStatus(resp); err != nil {
+		return ImportResult{}, err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+
+	var dat importResponse
+	if err := json.Unmarshal(body, &dat); err != nil {
+		return ImportResult{}, err
+	}
+
+	if err := errorFromResponse(dat.Response); err != nil {
+		return ImportResult{}, err
+	}
+	return dat.Result, nil
+}
+
+func newfileUploadRequest(apiToken, projectID, path, langISO string, opts *ImportOptions) (*http.Request, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", filepath.Base(path))
+	if err != nil {
+		return nil, err
+	}
+	_, err = io.Copy(part, file)
+	if err != nil {
+		return nil, err
+	}
+
+	err = multipartAdd(writer, "api_token", &apiToken)
+	if err != nil {
+		return nil, err
+	}
+	multipartAdd(writer, "id", &projectID)
+	if err != nil {
+		return nil, err
+	}
+	multipartAdd(writer, "lang_iso", &langISO)
+	if err != nil {
+		return nil, err
+	}
+	if opts != nil {
+		multipartAdd(writer, "fill_empty", boolString(opts.FillEmpty))
+		if err != nil {
+			return nil, err
+		}
+		multipartAdd(writer, "hidden", boolString(opts.Hidden))
+		if err != nil {
+			return nil, err
+		}
+		multipartAdd(writer, "distinguish", boolString(opts.Distinguish))
+		if err != nil {
+			return nil, err
+		}
+		multipartAdd(writer, "replace", boolString(opts.Replace))
+		if err != nil {
+			return nil, err
+		}
+		multipartAdd(writer, "replace_breaks", boolString(opts.ReplaceBreaks))
+		if err != nil {
+			return nil, err
+		}
+	}
+	err = writer.Close()
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest("POST", api("project/import"), body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", writer.FormDataContentType())
+	return req, nil
+}
+
+func multipartAdd(writer *multipart.Writer, field string, value *string) error {
+	if value == nil {
+		return nil
+	}
+	return writer.WriteField(field, *value)
+}

--- a/lokalise/list.go
+++ b/lokalise/list.go
@@ -1,0 +1,51 @@
+package lokalise
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+)
+
+// Project is the data model for a Lokalise project.
+type Project struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"desc"`
+	Created     Time   `json:"created"`
+	Owner       string `json:"owner"`
+}
+
+type listResponse struct {
+	Projects []Project `json:"projects"`
+	Response response  `json:"response"`
+}
+
+// List returns a slice of projects available for the apiToken.
+//
+// In case of API request errors an error of type Error is returned.
+func List(apiToken string) ([]Project, error) {
+	request, err := http.NewRequest(http.MethodGet, api("project/list?api_token="+apiToken), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := callAPI(request)
+	if err != nil {
+		return nil, err
+	}
+	if err := errorFromStatus(resp); err != nil {
+		return nil, err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	var dat listResponse
+	if err := json.Unmarshal(body, &dat); err != nil {
+		return nil, err
+	}
+	if err := errorFromResponse(dat.Response); err != nil {
+		return nil, err
+	}
+	return dat.Projects, nil
+}

--- a/lokalise/lokalise.go
+++ b/lokalise/lokalise.go
@@ -1,0 +1,81 @@
+// Package lokalise provides functions to access the Lokalise web API.
+// Each function has some required arguments and an options argument to modify the API behaviour.
+//
+// An API token is at minimum required. Information on how to generate one can be found at the
+// web API documentation at https://lokalise.co/apidocs.
+package lokalise
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	baseURL    = "https://api.lokalise.co/api/"
+	assetURL   = "https://s3-eu-west-1.amazonaws.com/lokalise-assets/"
+	timeout    = 10 * time.Second
+	timeFormat = "2006-01-02 15:04:05"
+)
+
+func callAPI(req *http.Request) (*http.Response, error) {
+	client := http.Client{
+		Timeout: timeout,
+	}
+	return client.Do(req)
+}
+
+func api(path string) string {
+	return baseURL + path
+}
+
+type response struct {
+	Status  string `json:"status"`
+	Code    Code   `json:"code"`
+	Message string `json:"message"`
+}
+
+const ()
+
+// A Time represents an instant in time with second precision.
+// It follows the Lokalise time format "2006-01-02 15:04:05".
+// The type embeds time.Time and can be used as such.
+type Time struct {
+	time.Time
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+// The time is expected to be a quoted string in RFC 3339 format.
+func (t *Time) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(string(b), "\"")
+	if s == "null" {
+		t.Time = time.Time{}
+		return nil
+	}
+	time, err := time.Parse(timeFormat, s)
+	if err != nil {
+		return err
+	}
+	t.Time = time
+	return nil
+}
+
+func jsonArray(s []string) *string {
+	if len(s) == 0 {
+		return nil
+	}
+	values := fmt.Sprintf("['%s']", strings.Join(s, "','"))
+	return &values
+}
+
+func boolString(b *bool) *string {
+	if b == nil {
+		return nil
+	}
+	v := "0"
+	if *b {
+		v = "1"
+	}
+	return &v
+}


### PR DESCRIPTION
I've marked it as WIP as I wan't to discuss some of the possibilities and I have some questions before completing this.

API request and CLI logic is split into separate packages. This closes #1.

## API logic
All logic surrounding the Lokalise Web API is now in package `lokalise`. There are three main functions exported, ie. `Import`, `Export`, `List` along with models for each function's input and output.

They follow the format of required arguments and an options struct with any modification flags of the functionality. This makes it possible to go with the default settings super easy and keep the same API if in need for more advanced options.

```go
lokalise.Import(apiToken, projectID, file, langISO string, opts *ImportOptions) (ImportResult, error) {
}
```
### Error handling
All error handling is pushed up the call stack. Errors from the API is wrapped into `lokalise.Error` structs that can be compared with the defined error codes from the documentation.

```go
res, err := lokalise.Import("token", "projectID", "/some/file.json", "da", nil)
if err != nil {
  apiErr, ok := err.(*lokalise.Error)
  if ok {
    switch apiErr.Code {
    case lokalise.InvalidAPIToken:
      // do stuff
    }
  }
}
```

I can add a `lokalise.IsError(err error) *Error` function to simplify above handling (like [os.IsNotExit](https://godoc.org/os#IsNotExist)) if you prefer that.

### Time format
The response of `/project/list` requests have a `created` field in the date format `2006-01-02 15:04:05`. As this is not an RFC3339 format I've implemented a `lokalise.Time` struct that unmarshals the date format correctly. The type embeds `time.Time` and can be used as such.

## CLI logic
This is mainly untouched. I've aligned the error handling so each command handler logs and exits on any errors. I've gone with just logging the error strings with `fmt.Printf` and then exit. This means no timestamps and other logging related parts. Is that fine with you? Before there was a mix of `fmt.Print`, `log.Fatal` and `panic`.

I've replaced some path string concatenations with `path.Join()` to make sure they work with operating systems where `/` is not the path separator.

## Undocumented parameters
There are two FIXMEs on undocumented fields in requests.

For the `/project/export` endpoint the source code sets a [`switch_no_language_folders`](https://github.com/lokalise/lokalise-cli-go/blob/master/lokalise.go#L266) and [`ota_plugin_bundle`](https://github.com/lokalise/lokalise-cli-go/blob/master/lokalise.go#L298) parameter but they are not mentioned in the [documentation](https://lokalise.co/apidocs#export). The first one is mentioned in the [change log](https://docs.lokalise.co/api-and-cli/lokalise-cli-tool) as added in v 0.46.

The same goes with the `/project/import` endpoint where [`use_trans_mem`](https://github.com/lokalise/lokalise-cli-go/blob/master/lokalise.go#L524) is set but it is not mentioned in the [docs](https://lokalise.co/apidocs#import).

Can you clear out what should happen with those? Are they missing in the docs or should they be removed from here?