### PR TITLE
Remove prefixed slash for export requests

### DIFF
--- a/lokalise/export.go
+++ b/lokalise/export.go
@@ -66,7 +66,7 @@ func Export(apiToken, projectID, fileType string, opts *ExportOptions) (Bundle, 
 	formAdd(form, "json_unescaped_slashes", boolString(opts.JSONUnescapedSlashes))
 	formAdd(form, "triggers", jsonArray(opts.Triggers))
 
-	req, err := http.NewRequest("POST", api("/project/export"), strings.NewReader(form.Encode()))
+	req, err := http.NewRequest("POST", api("project/export"), strings.NewReader(form.Encode()))
 	if err != nil {
 		return Bundle{}, err
 	}


### PR DESCRIPTION
#4 contained a bug that made the `lokalise.Export` function fail request to `https://api.lokalise.co/api//project/export`.
Not the double `/` before project.

This PR fixes that