### PR TITLE
Add godoc badge for Go API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # Lokalise CLI tool Golang sources
+[![GoDoc](https://godoc.org/github.com/lokalise/lokalise-cli-go?status.svg)](https://godoc.org/github.com/lokalise/lokalise-cli-go)
 
 https://docs.lokalise.co/api-and-cli/lokalise-cli-tool


### PR DESCRIPTION
This PR adds a Godoc badge linking to the godocs to the Go API