### PR TITLE
Functional option

### DIFF
--- a/lokalise.go
+++ b/lokalise.go
@@ -156,7 +156,11 @@ func main() {
 					Usage: "Other projects ID's, which keys to include in this export. (comma separated)",
 				},
 				cli.StringFlag{
-					Name:  "include_tags, tags",
+					Name:  "tags",
+					Usage: "Depreacted. Use include_tags instead: Only include keys with these tags (comma separated)",
+				},
+				cli.StringFlag{
+					Name:  "include_tags",
 					Usage: "Only include keys with these tags (comma separated)",
 				},
 				cli.StringFlag{
@@ -236,10 +240,10 @@ func main() {
 					dest = "."
 				}
 
-				// hack for now, need to think how to support legacy parameters
-				includeTags := c.String("include_tags");
-				if includeTags == "" {
-					includeTags = c.String("tags");
+				// map legacy flags to new names
+				if legacyTags := c.String("tags"); len(legacyTags) != 0 {
+					color.New(color.FgRed).Println("WARNING: --tags is deprecated. Use --include_tags instead.")
+					c.Set("include_tags", legacyTags)
 				}
 
 				opts := lokalise.ExportOptions{

--- a/lokalise.go
+++ b/lokalise.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -246,29 +247,28 @@ func main() {
 					c.Set("include_tags", legacyTags)
 				}
 
-				opts := lokalise.ExportOptions{
-					UseOriginal:          optionalBool(c.String("use_original")),
-					BundleStructure:      optionalString(c.String("bundle_structure")),
-					DirectoryPrefix:      optionalString(c.String("directory_prefix")),
-					WebhookURL:           optionalString(c.String("webhook_url")),
-					ExportAll:            optionalBool(c.String("export_all")),
-					ExportEmpty:          optionalString(c.String("export_empty")),
-					ExportSort:           optionalString(c.String("export_sort")),
-					PlaceholderFormat:    optionalString(c.String("placeholder_format")),
-					PluralFormat:         optionalString(c.String("plural_format")),
-					IncludeComments:      optionalBool(c.String("include_comments")),
-					ReplaceBreaks:        optionalBool(c.String("replace_breaks")),
-					YAMLIncludeRoot:      optionalBool(c.String("yaml_include_root")),
-					JSONUnescapedSlashes: optionalBool(c.String("json_unescaped_slashes")),
-					NoLanguageFolders:    optionalBool(c.String("no_language_folders")),
-					ICUNumeric:           optionalBool(c.String("icu_numeric")),
-					Languages:            commaSlice(c.String("langs")),
-					Filter:               commaSlice(c.String("filter")),
-					Triggers:             commaSlice(c.String("triggers")),
-					IncludePIDs:          commaSlice(c.String("include_pids")),
-					IncludeTags:          commaSlice(includeTags),
-					ExcludeTags:          commaSlice(c.String("exclude_tags")),
-				}
+				var opts []lokalise.ExportOption
+				opts = setExportBool(opts, c, "use_original", lokalise.WithOriginal)
+				opts = setExportString(opts, c, "bundle_structure", lokalise.WithBundleStructure)
+				opts = setExportString(opts, c, "directory_prefix", lokalise.WithDirectoryPrefix)
+				opts = setExportString(opts, c, "webhook_url", lokalise.WithWebhookURL)
+				opts = setExportBool(opts, c, "export_all", lokalise.WithAll)
+				opts = setExportString(opts, c, "export_empty", lokalise.WithEmpty)
+				opts = setExportString(opts, c, "export_sort", lokalise.WithSortOrder)
+				opts = setExportString(opts, c, "placeholder_format", lokalise.WithPlaceholderFormat)
+				opts = setExportString(opts, c, "plural_format", lokalise.WithPluralFormat)
+				opts = setExportBool(opts, c, "include_comments", lokalise.WithComments)
+				opts = setExportBool(opts, c, "replace_breaks", lokalise.WithExportReplaceBreaks)
+				opts = setExportBool(opts, c, "yaml_include_root", lokalise.WithYAMLRoot)
+				opts = setExportBool(opts, c, "json_unescaped_slashes", lokalise.WithJSONUnescapedSlashes)
+				opts = setExportBool(opts, c, "no_language_folders", lokalise.WithNoLanguageFolders)
+				opts = setExportBool(opts, c, "icu_numeric", lokalise.WithICUNumeric)
+				opts = setExportStrings(opts, c, "langs", lokalise.WithLanguages)
+				opts = setExportStrings(opts, c, "filter", lokalise.WithFilter)
+				opts = setExportStrings(opts, c, "triggers", lokalise.WithTriggers)
+				opts = setExportStrings(opts, c, "include_pids", lokalise.WithPIDs)
+				opts = setExportStrings(opts, c, "include_tags", lokalise.WithIncludeTags)
+				opts = setExportStrings(opts, c, "exclude_tags", lokalise.WithExcludeTags)
 
 				unzipTo := c.String("unzip_to")
 				keepZip := c.String("keep_zip")
@@ -283,7 +283,7 @@ func main() {
 				theSpinner.Start()
 				fmt.Print("Requesting...")
 
-				bundle, err := lokalise.Export(apiToken, projectID, fileType, &opts)
+				bundle, err := lokalise.Export(apiToken, projectID, fileType, opts...)
 				theSpinner.Stop()
 				if err != nil {
 					fmt.Printf("\n%v\n", err)
@@ -412,18 +412,18 @@ func main() {
 					return cli.NewExitError("ERROR: --lang_iso is required. If you are using filemask in --file parameter, make sure escape it (e.g. \\*.json).  Run `lokalise help import` for all options. ", 5)
 				}
 
-				importOptions := lokalise.ImportOptions{
-					Replace:             optionalBool(c.String("replace")),
-					ConvertPlaceholders: optionalBool(c.String("convert_placeholders")),
-					IcuPlurals:    	     optionalBool(c.String("icu_plurals")),
-					FillEmpty:     	     optionalBool(c.String("fill_empty")),
-					Distinguish:   	     optionalBool(c.String("distinguish")),
-					IncludePath:   	     optionalBool(c.String("include_path")),
-					Hidden:        	     optionalBool(c.String("hidden")),
-					UseTransMem:   	     optionalBool(c.String("use_trans_mem")),
-					Tags:          	     commaSlice(c.String("tags")),
-					ReplaceBreaks: 	     optionalBool(c.String("replace_breaks")),
-				}
+				includePath, _ := strconv.ParseBool(c.String("include_path"))
+
+				var opts []lokalise.ImportOption
+				opts = setImportBool(opts, c, "replce", lokalise.WithReplace)
+				opts = setImportBool(opts, c, "convert_placeholders", lokalise.WithConvertPlaceholders)
+				opts = setImportBool(opts, c, "icu_plurals", lokalise.WithICUPlurals)
+				opts = setImportBool(opts, c, "fill_empty", lokalise.WithFillEmpty)
+				opts = setImportBool(opts, c, "distinguish", lokalise.WithDistinguish)
+				opts = setImportBool(opts, c, "hidden", lokalise.WithHidden)
+				opts = setImportBool(opts, c, "use_trans_mem", lokalise.WithTranslationMemory)
+				opts = setImportStrings(opts, c, "tags", lokalise.WithTags)
+				opts = setImportBool(opts, c, "replace_breaks", lokalise.WithImportReplaceBreaks)
 
 				cWhite := color.New(color.FgHiWhite)
 				cGreen := color.New(color.FgGreen)
@@ -436,10 +436,13 @@ func main() {
 					}
 
 					for _, filename := range files {
+						if includePath {
+							opts = append(opts, lokalise.WithFilename(filename))
+						}
 						theSpinner := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 						cWhite.Printf("Uploading %s... ", filename)
 						theSpinner.Start()
-						result, err := lokalise.Import(apiToken, projectID, filename, langIso, &importOptions)
+						result, err := lokalise.Import(apiToken, projectID, filename, langIso, opts...)
 						theSpinner.Stop()
 						if err != nil {
 							fmt.Printf("\n%v\n", err)
@@ -482,6 +485,29 @@ func downloadFile(filepath string, url string) (err error) {
 	return nil
 }
 
+func setExportBool(opts []lokalise.ExportOption, c *cli.Context, cmdField string, f func(v bool) lokalise.ExportOption) []lokalise.ExportOption {
+	value := c.String(cmdField)
+	if value == "" {
+		return opts
+	}
+	b, _ := strconv.ParseBool(value)
+	return append(opts, f(b))
+}
+func setExportString(opts []lokalise.ExportOption, c *cli.Context, cmdField string, f func(v string) lokalise.ExportOption) []lokalise.ExportOption {
+	value := c.String(cmdField)
+	if value == "" {
+		return opts
+	}
+	return append(opts, f(value))
+}
+func setExportStrings(opts []lokalise.ExportOption, c *cli.Context, cmdField string, f func(v ...string) lokalise.ExportOption) []lokalise.ExportOption {
+	value := commaSlice(c.String(cmdField))
+	if len(value) == 0 {
+		return opts
+	}
+	return append(opts, f(value...))
+}
+
 func commaSlice(v string) []string {
 	if v == "" {
 		return nil
@@ -489,22 +515,27 @@ func commaSlice(v string) []string {
 	return strings.Split(v, ",")
 }
 
-func optionalBool(v string) *bool {
-	if v == "" {
-		return nil
+func setImportBool(opts []lokalise.ImportOption, c *cli.Context, cmdField string, f func(v bool) lokalise.ImportOption) []lokalise.ImportOption {
+	value := c.String(cmdField)
+	if value == "" {
+		return opts
 	}
-	var b bool
-	if v == "1" {
-		b = true
-	}
-	return &b
+	b, _ := strconv.ParseBool(value)
+	return append(opts, f(b))
 }
-
-func optionalString(v string) *string {
-	if v == "" {
-		return nil
+func setImportString(opts []lokalise.ImportOption, c *cli.Context, cmdField string, f func(v string) lokalise.ImportOption) []lokalise.ImportOption {
+	value := c.String(cmdField)
+	if len(value) == 0 {
+		return opts
 	}
-	return &v
+	return append(opts, f(value))
+}
+func setImportStrings(opts []lokalise.ImportOption, c *cli.Context, cmdField string, f func(v ...string) lokalise.ImportOption) []lokalise.ImportOption {
+	value := commaSlice(c.String(cmdField))
+	if len(value) == 0 {
+		return opts
+	}
+	return append(opts, f(value...))
 }
 
 func unzip(src, dest string) ([]string, error) {

--- a/lokalise/export_option.go
+++ b/lokalise/export_option.go
@@ -1,0 +1,261 @@
+package lokalise
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// ExportOption is a function setting options for an export request.
+type ExportOption func(*url.Values) error
+
+// WithLanguages returns an ExportOption setting what languages to export. If
+// omitted all language are exported.
+func WithLanguages(languages ...string) ExportOption {
+	return stringArrayField("langs", languages)
+}
+
+// WithOriginal returns an ExportOption setting whether to use orignal
+// filenames and formates languages to export.
+func WithOriginal(enabled bool) ExportOption {
+	return boolField("use_original", enabled)
+}
+
+// WithFilter returns an ExportOption setting a filter on the export data
+// range. Allows values are 'translated', 'nonfuzzy' and 'nonhidden'.
+func WithFilter(values ...string) ExportOption {
+	return stringArrayField("filter", values, allowedSliceStrings("translated", "nonfuzzy", "nonhidden"))
+}
+
+// WithBundleStructure returns an ExportOption setting the bundle structure.
+// Used when exporting all keys to a single file per language with WithOriginal(false).
+//
+// Available placeholders are %LANG_ISO%, %LANG_NAME%, %FORMAT% and %PROJECT_NAME%.
+//
+// Example:
+//   locale/%LANG_ISO%.%FORMAT%
+//
+// Option is ignored if WithOriginal(true) is set.
+func WithBundleStructure(structure string) ExportOption {
+	return stringField("bundle_structure", structure)
+}
+
+// WithDirectoryPrefix returns an ExportOption setting the directory prefix of
+// the bundle.
+// Used when exporting keys to previously assigned filenames with
+// WithOriginal(true).
+//
+// Available placeholders are %LANG_ISO%.
+//
+// Example:
+//   %LANG_ISO%/
+//
+// Option is ignored if WithOriginal(false) is set.
+func WithDirectoryPrefix(prefix string) ExportOption {
+	return stringField("directory_prefix", prefix)
+}
+
+// WithWebhookURL returns an ExportOption setting a webhook to call when
+// the export is completed.
+//
+// The webhook is an HTTP POST request with payload:
+//
+//  file=export/Sample_locale.zip
+//
+// When receiving the webhook, prepend 'https://s3-eu-west-1.amazonaws.com/lokalise-assets/'
+// to the filename in order to download the bundle.
+//
+// Use http.Request.PostFormValue() to get the filename:
+//
+//  func httpHandler(w http.ResponseWriter, req *http.Request) {
+//    filename := req.PostFormValue("file")
+//    // prepend assets URL and download bundle
+//    w.WriteHeader(http.StatusOK)
+//  }
+func WithWebhookURL(webhook string) ExportOption {
+	return stringField("webhook_url", webhook)
+}
+
+// WithAll returns an ExportOption setting whether to include all platform
+// keys.
+func WithAll(enabled bool) ExportOption {
+	return boolField("export_all", enabled)
+}
+
+// WithEmpty returns an ExportOption setting empty string export preferences.
+// Allowed values are "empty", "base" and "skip".
+func WithEmpty(value string) ExportOption {
+	return stringField("export_empty", value, allowedStrings("empty", "base", "skip"))
+}
+
+// WithComments returns an ExportOption setting whether to include key
+// comments (if supported by format).
+func WithComments(enabled bool) ExportOption {
+	return boolField("include_comments", enabled)
+}
+
+// WithPIDs returns an ExportOption setting other projects ID's to be included
+// with this export.
+func WithPIDs(pids ...string) ExportOption {
+	return stringArrayField("include_pids", pids)
+}
+
+// WithIncludeTags returns an ExportOption setting tags to limit export range.
+// Only keys with provided tags are included in export.
+func WithIncludeTags(tags ...string) ExportOption {
+	return stringArrayField("include_tags", tags)
+}
+
+// WithExcludeTags returns an ExportOption setting tags to exclude in export range.
+// Keys with provided tags are excluded in export.
+func WithExcludeTags(tags ...string) ExportOption {
+	return stringArrayField("exclude_tags", tags)
+}
+
+// WithSortOrder returns an ExportOption setting the sort order of exported keys.
+//
+// Allowed values are "first_added", "last_added", "last_updated", "a_z", "z_a".
+func WithSortOrder(order string) ExportOption {
+	return stringField("export_sort", order, allowedStrings("first_added", "last_added", "last_updated", "a_z", "z_a"))
+}
+
+// WithExportReplaceBreaks returns an ExportOption setting whether to replace '\n' with
+// line breaks.
+func WithExportReplaceBreaks(enabled bool) ExportOption {
+	return boolField("replace_breaks", enabled)
+}
+
+// WithYAMLRoot returns an ExportOption setting whether to include language ISO
+// code as root key.
+//
+// Only available for YAML exports set with the type argument to 'yaml'.
+func WithYAMLRoot(enabled bool) ExportOption {
+	return boolField("yaml_include_root", enabled)
+}
+
+// WithJSONUnescapedSlashes returns an ExportOption setting whether to leave
+// forward slashes unescaped.
+//
+// Only available for JSON exports set with the type argument to 'json'.
+func WithJSONUnescapedSlashes(enabled bool) ExportOption {
+	return boolField("json_unescaped_slashes", enabled)
+}
+
+// WithNoLanguageFolders returns an ExportOption setting whether to not use a
+// directory prefix.
+//
+// This is a legacy option. Use WithDirectoryPrefix("") instead.
+func WithNoLanguageFolders(enabled bool) ExportOption {
+	return boolField("no_language_folders", enabled)
+}
+
+// WithTriggers returns an ExportOption setting what integration exports to trigger.
+//
+// Ensure this feature is enabled in project settings before use.
+//
+// Allowed values are "amazon", "gcs" and "github".
+func WithTriggers(triggers ...string) ExportOption {
+	return stringArrayField("triggers", triggers, allowedSliceStrings("amazon", "gcs", "github"))
+}
+
+// WithPluralFormat returns an ExportOption overriding the default plural
+// format for the file type.
+//
+// Allowed values are "json_string", "icu", "array" and "generic".
+func WithPluralFormat(format string) ExportOption {
+	return stringField("plural_format", format, allowedStrings("json_string", "icu", "array", "generic"))
+}
+
+// WithICUNumeric returns an ExportOption setting whether the plural forms
+// "zero", "one" and "two" is replaced with "=0", "=1", "=2" respectively.
+//
+// Only available for when setting WithPluralFormat("icu")
+func WithICUNumeric(enabled bool) ExportOption {
+	return boolField("icu_numeric", enabled)
+}
+
+// WithPlaceholderFormat returns an ExportOption overriding the default
+// placeholder format for the file type.
+//
+// Allowed values are "printf", "ios", "icu" and "net".
+func WithPlaceholderFormat(format string) ExportOption {
+	return stringField("placeholder_format", format, allowedStrings("printf", "ios", "icu", "net"))
+}
+
+func boolField(field string, value bool) ExportOption {
+	return func(v *url.Values) error {
+		v.Add(field, boolString(value))
+		return nil
+	}
+}
+
+type validator func(string) error
+
+func stringField(field, value string, validators ...validator) ExportOption {
+	return func(v *url.Values) error {
+		for _, validator := range validators {
+			err := validator(value)
+			if err != nil {
+				return err
+			}
+		}
+		v.Add(field, strings.TrimSpace(value))
+		return nil
+	}
+}
+
+func allowedStrings(allowedValues ...string) validator {
+	return func(value string) error {
+		for _, v := range allowedValues {
+			if value == v {
+				return nil
+			}
+		}
+		return restrictedErr(allowedValues, value)
+	}
+}
+
+type sliceValidator func([]string) error
+
+func stringArrayField(field string, values []string, validators ...sliceValidator) ExportOption {
+	return func(v *url.Values) error {
+		for _, validator := range validators {
+			err := validator(values)
+			if err != nil {
+				return err
+			}
+		}
+		for i := range values {
+			values[i] = strings.TrimSpace(values[i])
+		}
+		jsonValues, err := json.Marshal(values)
+		if err != nil {
+			return err
+		}
+		v.Add(field, string(jsonValues))
+		return nil
+	}
+}
+
+func allowedSliceStrings(allowedValues ...string) sliceValidator {
+	return func(values []string) error {
+		for _, value := range values {
+			var allowed bool
+			for _, v := range allowedValues {
+				if value == v {
+					allowed = true
+					break
+				}
+			}
+			if !allowed {
+				return restrictedErr(allowedValues, value)
+			}
+		}
+		return nil
+	}
+}
+
+func restrictedErr(allowed []string, value string) error {
+	return fmt.Errorf("lokalise: allowed values '%s': value '%s' not allowed", strings.Join(allowed, "', '"), value)
+}

--- a/lokalise/import_option.go
+++ b/lokalise/import_option.go
@@ -1,0 +1,93 @@
+package lokalise
+
+import (
+	"encoding/json"
+	"mime/multipart"
+)
+
+// ImportOption is a function setting options for an import request.
+type ImportOption func(*multipart.Writer) error
+
+// WithReplace returns an ImportOption setting whether to replace existing
+// translations of the imported keys.
+func WithReplace(enabled bool) ImportOption {
+	return func(w *multipart.Writer) error {
+		return w.WriteField("replace", boolString(enabled))
+	}
+}
+
+// WithConvertPlaceholders returns an ImportOption setting whether to convert
+// placeholders to Lokalise universal ones. Enabled by default.
+// See https://docs.lokalise.co/developer-docs/universal-placeholders
+func WithConvertPlaceholders(enabled bool) ImportOption {
+	return func(w *multipart.Writer) error {
+		return w.WriteField("convert_placeholders", boolString(enabled))
+	}
+}
+
+// WithICUPlurals returns an ImportOption setting whether to automatically
+// detect and parse ICU formatted plurals.
+func WithICUPlurals(enabled bool) ImportOption {
+	return func(w *multipart.Writer) error {
+		return w.WriteField("icu_plurals", boolString(enabled))
+	}
+}
+
+// WithFillEmpty returns an ImportOption setting whether to fill empty values
+// with keys.
+func WithFillEmpty(enabled bool) ImportOption {
+	return func(w *multipart.Writer) error {
+		return w.WriteField("fill_empty", boolString(enabled))
+	}
+}
+
+// WithDistinguish returns an ImportOption setting whether to distinguish
+// similar keys in different files.
+func WithDistinguish(enabled bool) ImportOption {
+	return func(w *multipart.Writer) error {
+		return w.WriteField("distinguish", boolString(enabled))
+	}
+}
+
+// WithTranslationMemory returns an ImportOption setting whether to use
+// automatically fill 100% translation memory matches.
+func WithTranslationMemory(enabled bool) ImportOption {
+	return func(w *multipart.Writer) error {
+		return w.WriteField("use_trans_mem", boolString(enabled))
+	}
+}
+
+// WithHidden returns an ImportOption setting whether to hide newly added keys
+// from contributors.
+func WithHidden(enabled bool) ImportOption {
+	return func(w *multipart.Writer) error {
+		return w.WriteField("hidden", boolString(enabled))
+	}
+}
+
+// WithTags returns an ImportOption setting a list of tags for newly added
+// keys.
+func WithTags(tags ...string) ImportOption {
+	return func(w *multipart.Writer) error {
+		jsonTags, err := json.Marshal(tags)
+		if err != nil {
+			return err
+		}
+		return w.WriteField("tags", string(jsonTags))
+	}
+}
+
+// WithFilename returns an ImportOption setting an override of the filename.
+func WithFilename(filename string) ImportOption {
+	return func(w *multipart.Writer) error {
+		return w.WriteField("filename", filename)
+	}
+}
+
+// WithImportReplaceBreaks returns an ImportOption setting whether to replace '\n' with
+// line breaks.
+func WithImportReplaceBreaks(enabled bool) ImportOption {
+	return func(w *multipart.Writer) error {
+		return w.WriteField("replace_breaks", boolString(enabled))
+	}
+}

--- a/lokalise/lokalise.go
+++ b/lokalise/lokalise.go
@@ -6,7 +6,6 @@
 package lokalise
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -61,21 +60,9 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func jsonArray(s []string) *string {
-	if len(s) == 0 {
-		return nil
+func boolString(b bool) string {
+	if b {
+		return "1"
 	}
-	values := fmt.Sprintf("['%s']", strings.Join(s, "','"))
-	return &values
-}
-
-func boolString(b *bool) *string {
-	if b == nil {
-		return nil
-	}
-	v := "0"
-	if *b {
-		v = "1"
-	}
-	return &v
+	return "0"
 }


### PR DESCRIPTION
This PR closes #7 and replaces `ImportOptions` and `ExportOptions` structs with [functional options](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis) as discussed in #7.

I've implemented client side validation on the restricted string inputs, e.g. `--filter`, [but I'm not sure if it should stay](https://github.com/lokalise/lokalise-cli-go/issues/7#issuecomment-376063254).

I've also changed ([311c5da](https://github.com/lokalise/lokalise-cli-go/pull/8/commits/f3925293a5ce86c65cb0f4166b13308b2bcb3bfa)) the way the `--tags` migration to `--include_tags` is implemented. This way we can detect what flag was used and print a warning if it's the deprecated one.